### PR TITLE
Call the exe directly 

### DIFF
--- a/CoreKeeper.cs/CoreKeeper.cs
+++ b/CoreKeeper.cs/CoreKeeper.cs
@@ -35,7 +35,7 @@ namespace WindowsGSM.Plugins
         // - Game server Fixed variables
         public override string StartPath => @"CoreKeeperServer.exe"; // Game server start path
         public string FullName = "CoreKeeper Dedicated Server"; // Game server FullName
-        public bool AllowsEmbedConsole = true;  // Does this server support output redirect?
+        public bool AllowsEmbedConsole = false;  // Does this server support output redirect?
         public int PortIncrements = 10; // This tells WindowsGSM how many ports should skip after installation
         public object QueryMethod = new A2S(); // Query method should be use on current server type. Accepted value: null or new A2S() or new FIVEM() or new UT3()
 
@@ -83,26 +83,21 @@ namespace WindowsGSM.Plugins
             };
 
             // Set up Redirect Input and Output to WindowsGSM Console if EmbedConsole is on
-            if (serverData.EmbedConsole)
-            {
-                p.StartInfo.CreateNoWindow = true;
-                p.StartInfo.RedirectStandardInput = true;
-                p.StartInfo.RedirectStandardOutput = true;
-                p.StartInfo.RedirectStandardError = true;
-                var serverConsole = new ServerConsole(serverData.ServerID);
-                p.OutputDataReceived += serverConsole.AddOutput;
-                p.ErrorDataReceived += serverConsole.AddOutput;
-            }
+            p.StartInfo.CreateNoWindow = true;
+            p.StartInfo.RedirectStandardInput = true;
+            p.StartInfo.RedirectStandardOutput = true;
+            p.StartInfo.RedirectStandardError = true;
+            var serverConsole = new ServerConsole(serverData.ServerID);
+            p.OutputDataReceived += serverConsole.AddOutput;
+            p.ErrorDataReceived += serverConsole.AddOutput;
+
 
             // Start Process
             try
             {
                 p.Start();
-                if (serverData.EmbedConsole)
-                {
-                    p.BeginOutputReadLine();
-                    p.BeginErrorReadLine();
-                }
+                p.BeginOutputReadLine();
+                p.BeginErrorReadLine();
                 return p;
             }
             catch (Exception e)

--- a/CoreKeeper.cs/CoreKeeper.cs
+++ b/CoreKeeper.cs/CoreKeeper.cs
@@ -33,7 +33,7 @@ namespace WindowsGSM.Plugins
         public CoreKeeper(ServerConfig serverData) : base(serverData) => base.serverData = serverData;
 
         // - Game server Fixed variables
-        public override string StartPath => @"Launch.bat"; // Game server start path
+        public override string StartPath => @"CoreKeeperServer.exe"; // Game server start path
         public string FullName = "CoreKeeper Dedicated Server"; // Game server FullName
         public bool AllowsEmbedConsole = true;  // Does this server support output redirect?
         public int PortIncrements = 10; // This tells WindowsGSM how many ports should skip after installation
@@ -65,13 +65,8 @@ namespace WindowsGSM.Plugins
                 return null;
             }
 
-
-
             // Prepare start parameter
-
-            string param = $"-batchmode {serverData.ServerParam}" + (!AllowsEmbedConsole ? " -log" : string.Empty);
-
-
+            string param = $"-batchmode -logfile CoreKeeperServerLog.txt {serverData.ServerParam}";
 
             // Prepare Process
             var p = new Process

--- a/CoreKeeper.cs/CoreKeeper.cs
+++ b/CoreKeeper.cs/CoreKeeper.cs
@@ -20,7 +20,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.CoreKeeper", // WindowsGSM.XXXX
             author = "Geekbee",
             description = "WindowsGSM plugin for supporting CoreKeeper Dedicated Server",
-            version = "1.0",
+            version = "1.1",
             url = "https://github.com/GeekbeeGER/WindowsGSM.CoreKeeper", // Github repository link (Best practice)
             color = "#34c9ec" // Color Hex
         };
@@ -30,10 +30,7 @@ namespace WindowsGSM.Plugins
         public override string AppId => "1963720"; // Game server appId
 
         // - Standard Constructor and properties
-        public CoreKeeper(ServerConfig serverData) : base(serverData) => base.serverData = _serverData = serverData;
-        private readonly ServerConfig _serverData;
-        public string Error, Notice;
-
+        public CoreKeeper(ServerConfig serverData) : base(serverData) => base.serverData = serverData;
 
         // - Game server Fixed variables
         public override string StartPath => @"Launch.bat"; // Game server start path
@@ -60,20 +57,20 @@ namespace WindowsGSM.Plugins
         // - Start server function, return its Process to WindowsGSM
         public async Task<Process> Start()
         {
-			
-            string shipExePath = Functions.ServerPath.GetServersServerFiles(_serverData.ServerID, StartPath);
+
+            string shipExePath = Functions.ServerPath.GetServersServerFiles(serverData.ServerID, StartPath);
             if (!File.Exists(shipExePath))
             {
                 Error = $"{Path.GetFileName(shipExePath)} not found ({shipExePath})";
                 return null;
-            }			
-			
-		
+            }
+
+
 
             // Prepare start parameter
 
-			string param = $"-batchmode {_serverData.ServerParam}" + (!AllowsEmbedConsole ? " -log" : string.Empty);	
-	
+            string param = $"-batchmode {serverData.ServerParam}" + (!AllowsEmbedConsole ? " -log" : string.Empty);
+
 
 
             // Prepare Process
@@ -81,7 +78,7 @@ namespace WindowsGSM.Plugins
             {
                 StartInfo =
                 {
-                    WorkingDirectory = ServerPath.GetServersServerFiles(_serverData.ServerID),
+                    WorkingDirectory = ServerPath.GetServersServerFiles(serverData.ServerID),
                     FileName = shipExePath,
                     Arguments = param,
                     WindowStyle = ProcessWindowStyle.Minimized,
@@ -97,7 +94,7 @@ namespace WindowsGSM.Plugins
                 p.StartInfo.RedirectStandardInput = true;
                 p.StartInfo.RedirectStandardOutput = true;
                 p.StartInfo.RedirectStandardError = true;
-                var serverConsole = new ServerConsole(_serverData.ServerID);
+                var serverConsole = new ServerConsole(serverData.ServerID);
                 p.OutputDataReceived += serverConsole.AddOutput;
                 p.ErrorDataReceived += serverConsole.AddOutput;
 
@@ -129,8 +126,8 @@ namespace WindowsGSM.Plugins
                 return null; // return null if fail to start
             }
         }
-	
-	   // - Stop server function
-	   public async Task Stop(Process p) => await Task.Run(() => { p.Kill(); }); // I believe Core Keeper don't have a proper way to stop the server so just kill it
+
+        // - Stop server function
+        public async Task Stop(Process p) => await Task.Run(() => { p.Kill(); }); // I believe Core Keeper don't have a proper way to stop the server so just kill it
     }
 }

--- a/CoreKeeper.cs/CoreKeeper.cs
+++ b/CoreKeeper.cs/CoreKeeper.cs
@@ -41,11 +41,11 @@ namespace WindowsGSM.Plugins
 
 
         // - Game server default values
-        public string Port = "9000"; // Default port
+        public string Port = "27016"; // Default port
         public string QueryPort = "9100"; // Default query port
         public string Defaultmap = "map"; // Default map name
         public string Maxplayers = "100"; // Default maxplayers
-        public string Additional = ""; // Additional server start parameter
+        public string Additional = "-datapath \"Saves\""; // Additional server start parameter
 
 
         // - Create a default cfg for the game server after installation
@@ -66,7 +66,11 @@ namespace WindowsGSM.Plugins
             }
 
             // Prepare start parameter
-            string param = $"-batchmode -logfile CoreKeeperServerLog.txt {serverData.ServerParam}";
+            string param = $"-batchmode -log" +
+                $" -logfile CoreKeeperServerLog.txt" +
+                $" -maxplayers {serverData.ServerMaxPlayer}" +
+                // $" -port {serverData.ServerPort}" +
+                $" {serverData.ServerParam}";
 
             // Prepare Process
             var p = new Process

--- a/CoreKeeper.cs/CoreKeeper.cs
+++ b/CoreKeeper.cs/CoreKeeper.cs
@@ -88,7 +88,7 @@ namespace WindowsGSM.Plugins
             };
 
             // Set up Redirect Input and Output to WindowsGSM Console if EmbedConsole is on
-            if (AllowsEmbedConsole)
+            if (serverData.EmbedConsole)
             {
                 p.StartInfo.CreateNoWindow = true;
                 p.StartInfo.RedirectStandardInput = true;
@@ -97,27 +97,17 @@ namespace WindowsGSM.Plugins
                 var serverConsole = new ServerConsole(serverData.ServerID);
                 p.OutputDataReceived += serverConsole.AddOutput;
                 p.ErrorDataReceived += serverConsole.AddOutput;
-
-                // Start Process
-                try
-                {
-                    p.Start();
-                }
-                catch (Exception e)
-                {
-                    Error = e.Message;
-                    return null; // return null if fail to start
-                }
-
-                p.BeginOutputReadLine();
-                p.BeginErrorReadLine();
-                return p;
             }
 
             // Start Process
             try
             {
                 p.Start();
+                if (serverData.EmbedConsole)
+                {
+                    p.BeginOutputReadLine();
+                    p.BeginErrorReadLine();
+                }
                 return p;
             }
             catch (Exception e)

--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ https://store.steampowered.com/app/1621690/Core_Keeper/
 
 # Important
 - Your Game Id is stored inside Server Files as GameID.txt (click Browse => Server Files in Wgsm)
+- Your World Save is stored in ServerFiles\Saves 
 - To configure your server go to %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\DedicatedServer and edit ServerConfig.json
 - If you want to import a world copy it
   - from your client %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\Steam\$YourSteamID\worlds\0.world.gzip
-  - to your server  %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\DedicatedServer\worlds\0.world.gzip
+  - to your server serverfiles\Saves\worlds\0.world.gzip (or default if you don't override default location %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\DedicatedServer\worlds\0.world.gzip)
+- If you don't want to use steam relay service, add parameter "-port 27015" (27015-27050) to host on your own ip. That needs Portforwarding of Port XXXXX TCP/UDP)
+
 
 # Installation
 1. Download the latest release

--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ https://store.steampowered.com/app/1621690/Core_Keeper/
 1. Download the latest release
 2. Move CoreKeeper.cs folder to plugins folder
 3. Click [RELOAD PLUGINS] button or restart WindowsGSM
+
+### Support
+[WGSM](https://discord.com/channels/590590698907107340/645730252672335893)
+
+### Give Love!
+[Buy me a coffee](https://ko-fi.com/raziel7893)
+
+[Paypal](https://paypal.me/raziel7893)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ https://store.steampowered.com/app/1621690/Core_Keeper/
 - If you want to import a world copy it
   - from your client %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\Steam\$YourSteamID\worlds\0.world.gzip
   - to your server serverfiles\Saves\worlds\0.world.gzip (or default if you don't override default location %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\DedicatedServer\worlds\0.world.gzip)
-- If you don't want to use steam relay service, add parameter "-port 27015" (27015-27050) to host on your own ip. That needs Portforwarding of Port XXXXX TCP/UDP)
+- If you don't want to use steam relay service, add parameter "-port 27015" (27015-27050) to host on your own ip. That needs Portforwarding of Port XXXXX TCP/UDP and a semi-static IPv4)
 
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 https://store.steampowered.com/app/1621690/Core_Keeper/
 
 # Important
-%USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\DedicatedServer to Config Server, and get your gameId for Connect
+- Your Game Id is stored inside Server Files as GameID.txt (click Browse => Server Files in Wgsm)
+- To configure your server go to %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\DedicatedServer and edit ServerConfig.json
+- If you want to import a world copy it
+  - from your client %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\Steam\$YourSteamID\worlds\0.world.gzip
+  - to your server  %USERPROFILE%\AppData\LocalLow\Pugstorm\Core Keeper\DedicatedServer\worlds\0.world.gzip
 
 # Installation
 1. Download the latest release


### PR DESCRIPTION
- changed plugin to use directly the exe file and not a bat file to launch a powershell script to start the exe. This caused many instances of the server running in the background detached from wgsm.
- cleaned up and added a default savedir override so the world is not somewhere in appdata (so the backup function can actually backup anything)